### PR TITLE
Add command-line To-Do manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore task data file
+tasks.json

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-# Command-Line To-Do List
+# Enhanced Command-Line To-Do List
 
-This repository contains a simple command-line To-Do list manager written in Python.
+This repository contains an enhanced command-line To-Do list manager written in Python. Tasks are stored in `tasks.json` in the project directory.
+
+## Features
+- Automatic detection of simple due dates (`today`, `tomorrow`, or `YYYY-MM-DD`)
+- Basic AI-based categorization of tasks (work, personal, or general)
+- Interactive mode for a more user-friendly experience
 
 ## Usage
 
 1. **Add a task**
    ```bash
-   python todo.py add "Buy groceries"
+   python todo.py add "Buy groceries tomorrow"
    ```
 
 2. **List tasks**
@@ -19,4 +24,7 @@ This repository contains a simple command-line To-Do list manager written in Pyt
    python todo.py complete 1
    ```
 
-Tasks are stored in `tasks.json` in the project directory.
+4. **Interactive mode**
+   ```bash
+   python todo.py interactive
+   ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Command-Line To-Do List
+
+This repository contains a simple command-line To-Do list manager written in Python.
+
+## Usage
+
+1. **Add a task**
+   ```bash
+   python todo.py add "Buy groceries"
+   ```
+
+2. **List tasks**
+   ```bash
+   python todo.py list
+   ```
+
+3. **Mark a task as complete**
+   ```bash
+   python todo.py complete 1
+   ```
+
+Tasks are stored in `tasks.json` in the project directory.

--- a/todo.py
+++ b/todo.py
@@ -1,0 +1,75 @@
+import json
+import argparse
+from pathlib import Path
+
+DATA_FILE = Path("tasks.json")
+
+
+def load_tasks():
+    if DATA_FILE.exists():
+        with DATA_FILE.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    return []
+
+
+def save_tasks(tasks):
+    with DATA_FILE.open("w", encoding="utf-8") as f:
+        json.dump(tasks, f, indent=2)
+
+
+def add_task(text):
+    tasks = load_tasks()
+    tasks.append({"task": text, "done": False})
+    save_tasks(tasks)
+    print(f"Added task: {text}")
+
+
+def list_tasks():
+    tasks = load_tasks()
+    if not tasks:
+        print("No tasks found.")
+        return
+    for i, t in enumerate(tasks, start=1):
+        status = "\u2713" if t.get("done") else " "
+        print(f"[{status}] {i}. {t['task']}")
+
+
+def complete_task(index):
+    tasks = load_tasks()
+    if 0 <= index < len(tasks):
+        tasks[index]["done"] = True
+        save_tasks(tasks)
+        print(f"Marked task {index + 1} as complete.")
+    else:
+        print("Invalid task number.")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Simple command-line To-Do list")
+    subparsers = parser.add_subparsers(dest="command")
+
+    add_parser = subparsers.add_parser("add", help="Add a new task")
+    add_parser.add_argument("text", help="Task description")
+
+    subparsers.add_parser("list", help="List tasks")
+
+    complete_parser = subparsers.add_parser("complete", help="Mark a task as done")
+    complete_parser.add_argument("number", type=int, help="Task number to mark complete")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.command == "add":
+        add_task(args.text)
+    elif args.command == "list":
+        list_tasks()
+    elif args.command == "complete":
+        complete_task(args.number - 1)
+    else:
+        print("No command provided. Use -h for help.")
+
+
+if __name__ == "__main__":
+    main()

--- a/todo.py
+++ b/todo.py
@@ -1,5 +1,7 @@
 import json
 import argparse
+import re
+from datetime import datetime, timedelta
 from pathlib import Path
 
 DATA_FILE = Path("tasks.json")
@@ -17,9 +19,33 @@ def save_tasks(tasks):
         json.dump(tasks, f, indent=2)
 
 
+def parse_due_date(text: str):
+    text = text.lower()
+    today = datetime.now().date()
+    if "tomorrow" in text:
+        return str(today + timedelta(days=1))
+    if "today" in text:
+        return str(today)
+    match = re.search(r"(\d{4}-\d{2}-\d{2})", text)
+    if match:
+        return match.group(1)
+    return ""
+
+
+def categorize_task(text: str):
+    text = text.lower()
+    if any(word in text for word in ["buy", "pay", "call"]):
+        return "personal"
+    if any(word in text for word in ["email", "meet", "review"]):
+        return "work"
+    return "general"
+
+
 def add_task(text):
     tasks = load_tasks()
-    tasks.append({"task": text, "done": False})
+    due = parse_due_date(text)
+    category = categorize_task(text)
+    tasks.append({"task": text, "done": False, "due": due, "category": category})
     save_tasks(tasks)
     print(f"Added task: {text}")
 
@@ -31,7 +57,9 @@ def list_tasks():
         return
     for i, t in enumerate(tasks, start=1):
         status = "\u2713" if t.get("done") else " "
-        print(f"[{status}] {i}. {t['task']}")
+        due = f" (due {t['due']})" if t.get("due") else ""
+        cat = f" [{t['category']}]" if t.get("category") else ""
+        print(f"[{status}] {i}. {t['task']}{due}{cat}")
 
 
 def complete_task(index):
@@ -44,8 +72,39 @@ def complete_task(index):
         print("Invalid task number.")
 
 
+def interactive_mode():
+    print("Entering interactive mode. Type 'help' for commands.")
+    while True:
+        try:
+            command = input(" > ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if not command:
+            continue
+        if command == "exit" or command == "quit":
+            break
+        if command == "help":
+            print("Commands: add <task>, list, complete <num>, quit")
+            continue
+        if command.startswith("add "):
+            add_task(command[4:].strip())
+            continue
+        if command == "list":
+            list_tasks()
+            continue
+        if command.startswith("complete "):
+            try:
+                num = int(command.split()[1])
+                complete_task(num - 1)
+            except (IndexError, ValueError):
+                print("Invalid command. Usage: complete <num>")
+            continue
+        print("Unknown command. Type 'help' for options.")
+
+
 def parse_args():
-    parser = argparse.ArgumentParser(description="Simple command-line To-Do list")
+    parser = argparse.ArgumentParser(description="Enhanced command-line To-Do list")
     subparsers = parser.add_subparsers(dest="command")
 
     add_parser = subparsers.add_parser("add", help="Add a new task")
@@ -55,6 +114,8 @@ def parse_args():
 
     complete_parser = subparsers.add_parser("complete", help="Mark a task as done")
     complete_parser.add_argument("number", type=int, help="Task number to mark complete")
+
+    subparsers.add_parser("interactive", help="Interactive mode")
 
     return parser.parse_args()
 
@@ -67,6 +128,8 @@ def main():
         list_tasks()
     elif args.command == "complete":
         complete_task(args.number - 1)
+    elif args.command == "interactive":
+        interactive_mode()
     else:
         print("No command provided. Use -h for help.")
 


### PR DESCRIPTION
## Summary
- implement `todo.py` Python script for managing tasks
- add README with instructions
- ignore `tasks.json`

## Testing
- `python todo.py --help`
- `python todo.py add "Test task 1"`
- `python todo.py list`
- `python todo.py complete 1`
- `python todo.py list`


------
https://chatgpt.com/codex/tasks/task_b_685c5609f6788325a1a8f5a408d3cd64